### PR TITLE
setup.py: set proper python requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,4 +42,5 @@ setup(
     ],
     packages=['wfepy'],
     install_requires=['attrs', 'graphviz'],
+    python_requires='>=3.5, <4',
 )


### PR DESCRIPTION
Only py3.5+ is supported

Signed-off-by: Martin Bašti <mbasti@redhat.com>