### PR TITLE
Add completed tasks set

### DIFF
--- a/tests/test_runner/test_waiting_branches.py
+++ b/tests/test_runner/test_waiting_branches.py
@@ -5,32 +5,32 @@ import wfepy
 
 @wfepy.task()
 @wfepy.start_point()
-@wfepy.followed_by('blocked')
-@wfepy.followed_by('not_blocked')
-def start(ctx):
-    ctx.done.add('start')
+@wfepy.followed_by('blocked_wb')
+@wfepy.followed_by('not_blocked_wb')
+def start_wb(ctx):
+    ctx.done.add('start_wb')
     return True
 
 
 @wfepy.task()
-@wfepy.followed_by('end')
-def blocked(ctx):
-    ctx.done.add('blocked')
+@wfepy.followed_by('end_wb')
+def blocked_wb(ctx):
+    ctx.done.add('blocked_wb')
     return not ctx.blocked
 
 
 @wfepy.task()
-@wfepy.followed_by('end')
-def not_blocked(ctx):
-    ctx.done.add('not_blocked')
+@wfepy.followed_by('end_wb')
+def not_blocked_wb(ctx):
+    ctx.done.add('not_blocked_wb')
     return True
 
 
 @wfepy.task()
 @wfepy.join_point()
 @wfepy.end_point()
-def end(ctx):
-    ctx.done.add('end')
+def end_wb(ctx):
+    ctx.done.add('end_wb')
     return True
 
 
@@ -59,7 +59,7 @@ class RunnerWaitingBranchesTestCase(unittest.TestCase):
         """Test if runner was created with start points."""
         runner = self.workflow.create_runner()
         self.assertIsInstance(runner, wfepy.Runner)
-        self.assertListEqual(runner.state, [('start', wfepy.TaskState.NEW)])
+        self.assertListEqual(runner.state, [('start_wb', wfepy.TaskState.NEW)])
 
     def test_run(self):
         """Test if run was finished and all tasks executed."""
@@ -68,14 +68,17 @@ class RunnerWaitingBranchesTestCase(unittest.TestCase):
 
         runner.run()
         self.assertFalse(runner.finished)
-        self.assertSetEqual(context.done, {'start', 'blocked', 'not_blocked'})
+        self.assertSetEqual(context.done, {'start_wb', 'blocked_wb', 'not_blocked_wb'})
 
         runner.run()
         self.assertFalse(runner.finished)
-        self.assertSetEqual(context.done, {'start', 'blocked', 'not_blocked'})
+        self.assertSetEqual(context.done, {'start_wb', 'blocked_wb', 'not_blocked_wb'})
 
         context.blocked = False
 
         runner.run()
         self.assertTrue(runner.finished)
-        self.assertSetEqual(context.done, {'start', 'blocked', 'not_blocked', 'end'})
+        self.assertSetEqual(context.done, {'start_wb',
+                                           'blocked_wb',
+                                           'not_blocked_wb',
+                                           'end_wb'})


### PR DESCRIPTION
Add completed tasks set to check if preceding tasks are completed or not.
There is an old logic in workflow.py:
if len(join_task.preceded_by) == len(join_list):
It is used to check if current task is blocked or not, but there is an exceptional case when removing a subtask before a join point, original len(join_task.preceded_by)-len(join_list)=1, after removing a preceding task, the two length will be equal which result in wrong logic.
This patch add a completed tasks set and check if preceding tasks names are in completed tasks instead of checking the length.

Change the tests' task names in test_waiting_branches.py as context.done will be affected by tests in test_waiting.py.

Some minor flake8 issue as well.

JIRA: RHELWF-7410